### PR TITLE
Update for Kubernetes 1.18

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,44 +1,74 @@
-pipeline:
-  build_docker_image:
-    image: docker:17.07.0
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-    commands:
-      - docker build -t quay.io/ukhomeofficedigital/kube-export:$${DRONE_COMMIT_SHA} .
-    when:
-      event: [push, tag]
+---
+kind: pipeline
+name: default
+type: kubernetes
 
-  scan:
-    image: quay.io/ukhomeofficedigital/anchore-submission:latest
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build_docker_image
+  pull: if-not-exists
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  commands:
+  - docker build -t quay.io/ukhomeofficedigital/kube-export:$${DRONE_COMMIT_SHA} .
+  when:
+    event:
+    - push
+    - tag
+
+- name: scan
+  pull: if-not-exists
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission
+  settings:
     dockerfile: Dockerfile
+    fail_on_detection: true
     image_name: quay.io/ukhomeofficedigital/kube-export:${DRONE_COMMIT_SHA}
     tolerates: medium
-    fail_on_detection: true
-    when:
-      event: push
+  when:
+    event:
+    - push
 
-  image_to_quay:
-    image: docker:17.07.0
-    secrets: [docker_password]
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-    commands:
-      - docker login -u="ukhomeofficedigital+drone_docker_kube_export" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag quay.io/ukhomeofficedigital/kube-export:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/kube-export:latest
-      - docker push quay.io/ukhomeofficedigital/kube-export:$${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/kube-export:latest
-    when:
-      event: push
-      branch: master
+- name: image_to_quay
+  pull: if-not-exists
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  commands:
+  - docker login -u="ukhomeofficedigital+drone_docker_kube_export" -p=$${DOCKER_PASSWORD} quay.io
+  - docker tag quay.io/ukhomeofficedigital/kube-export:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/kube-export:latest
+  - docker push quay.io/ukhomeofficedigital/kube-export:$${DRONE_COMMIT_SHA}
+  - docker push quay.io/ukhomeofficedigital/kube-export:latest
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+  when:
+    branch:
+    - master
+    event:
+    - push
 
-  tagged_image_to_quay:
-    image: docker:17.07.0
-    secrets: [docker_password]
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-    commands:
-      - docker login -u="ukhomeofficedigital+drone_docker_kube_export" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag quay.io/ukhomeofficedigital/kube-export:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/kube-export:$${DRONE_TAG}
-      - docker push quay.io/ukhomeofficedigital/kube-export:$${DRONE_TAG}
-    when:
-      event: tag
+- name: tagged_image_to_quay
+  pull: if-not-exists
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  commands:
+  - docker login -u="ukhomeofficedigital+drone_docker_kube_export" -p=$${DOCKER_PASSWORD} quay.io
+  - docker tag quay.io/ukhomeofficedigital/kube-export:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/kube-export:$${DRONE_TAG}
+  - docker push quay.io/ukhomeofficedigital/kube-export:$${DRONE_TAG}
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+  when:
+    event:
+    - tag
+
+services:
+- name: docker
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+
+- name: anchore-submission-server
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission
+  commands:
+  - /run.sh server
+  when:
+    event:
+    - push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM quay.io/ukhomeofficedigital/kd:v1.14.0
+FROM quay.io/ukhomeofficedigital/kd:v1.18.0
 
-RUN apk add --update --no-cache bash tar groff less python py-pip && \
-    pip install awscli && \
-    apk --purge -v del py-pip
+RUN apk add --update --no-cache bash tar groff less python3 py-pip jq && \
+    pip install awscli six yq
 
 COPY bin/backup.sh /usr/local/bin/backup.sh
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The following environment variables can be passed in to configure kube export ba
 | ENVIRONMENT VARIABLE | DESCRIPTION | REQUIRED | DEFAULT VALUE |
 |----------------------|-------------|----------|---------------|
 | BACKUP_PATH | Set the directory to copy the kube-export backup to | N | `/tmp` |
-| INSECURE_SKIP_TLS_VERIFY | Skip TLS verify for the Kube API | N | `false` |
 | KUBE_SERVER | API endpoint for the Kubernetes Cluster | N | `${KUBERNETES_SERVICE_HOST}:${KUBERNETES_PORT_443_TCP_PORT}` |
 | KUBE_TOKEN | Access Token to interact with the API | N | `$(</var/run/secrets/kubernetes.io/serviceaccount/token)` |
 | S3_AWS_ENDPOINT | Custom S3 endpoint URL | N | NULL |

--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -66,7 +66,16 @@ function tar_backup() {
 # Creates a backup of the current cluster
 function clusterbackup() {
   info "Starting Cluster Backup"
-  kd run get all,secret,configmap --export=true --all-namespaces=true -o yaml > ${BACKUP_FILE}
+  # get yaml of resources without unneeded fields
+  kd run get all,secret,configmap --all-namespaces=true -o yaml | yq -y \
+    'del(
+      .metadata.creationTimestamp,
+      .metadata.generation,
+      .metadata.namespace,
+      .metadata.resourceVersion,
+      .metadata.uid,
+      .status
+    )' > ${BACKUP_FILE}
   tar_backup
   move_s3
 }


### PR DESCRIPTION
The backup command has been changed as the `--export` flag has been deprecated since Kubernetes v1.14 and in v1.19 it has been removed completely (https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#deprecation). There isn't a replacment for it, but we can achieve a similar effect using [yq](https://github.com/kislyuk/yq) ([the command was adapted from here](https://www.reddit.com/r/kubernetes/comments/fm490y/is_something_replacing_export/fl2ev58?utm_source=share&utm_medium=web2x&context=3)).

The `INSECURE_SKIP_TLS_VERIFY` isn't actually used in this repo. It is an environment variable for [KD](https://github.com/UKHomeOffice/kd#kubectl-flags), however we already have a note in the README stating that KD's environment variables are supported.

Also moving the repo to Drone v1