### PR TITLE
Change to export by namespace and use background processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM quay.io/ukhomeofficedigital/kd:v1.18.0
 
-RUN apk add --update --no-cache bash tar groff less python3 py-pip jq && \
-    pip install awscli six yq
+RUN apk add --update --no-cache bash tar groff less python3 py-pip && \
+    apk add --no-cache yq>4.0.0 --repository https://dl-cdn.alpinelinux.org/alpine/edge/community && \
+    pip install awscli six
 
 COPY bin/backup.sh /usr/local/bin/backup.sh
 

--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -19,9 +19,9 @@ KUBE_SERVER=${KUBE_SERVER:-https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_PORT_
 KUBE_TOKEN=${KUBE_TOKEN:-$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)}
 
 DATESTAMP=`date +%Y%m%d_%H%M`
-BACKUP_PATH=${BACKUP_PATH:-"/tmp"}
-BACKUP_FILE=${BACKUP_PATH}/kube_resources.yml
-BACKUP_TAR=${BACKUP_PATH}/kube_resources_${DATESTAMP}.tar.gz
+BACKUP_PATH="${BACKUP_PATH:-"/tmp"}"
+BACKUP_KUBE_PATH="${BACKUP_PATH}/kube-resources" # temporary backup path for kube resources
+BACKUP_TAR="${BACKUP_PATH}/kube_resources_${DATESTAMP}.tar.gz"
 
 function move_s3() {
   # No-op when no backup
@@ -35,7 +35,7 @@ function move_s3() {
 
   # Check destination before uploading
   if [[ -f ${BACKUP_TAR} ]]; then
-    info "Uploading backed up file to s3"
+    info "Uploading backed up file to S3"
     if [[ -n ${S3_CA_BUNDLE} ]]; then
       s3cli_args+=" --ca-bundle ${S3_CA_BUNDLE}"
     elif [[ ${S3_NO_SSL_VERIFY} == true ]]; then
@@ -55,27 +55,42 @@ function move_s3() {
 }
 
 function tar_backup() {
+  info "Backing up to tar file..."
   (
-    cd ${BACKUP_PATH}
-    tar -cvzf ${BACKUP_TAR} ${BACKUP_FILE}
-    rm -fr ${BACKUP_FILE}
+    cd "${BACKUP_PATH}"
+    tar -cvzf "${BACKUP_TAR}" -C "${BACKUP_KUBE_PATH}" .
+    rm -fr "${BACKUP_KUBE_PATH}"
   )
   info "Backed up to: ${BACKUP_TAR}"
 }
 
 # Creates a backup of the current cluster
 function clusterbackup() {
+  mkdir -p "${BACKUP_KUBE_PATH}"
+
   info "Starting Cluster Backup"
-  # get yaml of resources without unneeded fields
-  kd run get all,secret,configmap --all-namespaces=true -o yaml | yq -y \
-    'del(
-      .metadata.creationTimestamp,
-      .metadata.generation,
-      .metadata.namespace,
-      .metadata.resourceVersion,
-      .metadata.uid,
-      .status
-    )' > ${BACKUP_FILE}
+
+  # backup each namespace's resources
+  for namespace in $(kd run get ns -o json | yq e '.items[].metadata.name' -); do
+    info "Starting export for ${namespace} namespace..."
+    # get yaml of resources without unneeded fields
+    kd run -n "${namespace}" get all,secret,configmap -o yaml | yq e \
+      'del(
+        .items[].metadata.creationTimestamp,
+        .items[].metadata.generation,
+        .items[].metadata.managedFields,
+        .items[].metadata.namespace,
+        .items[].metadata.resourceVersion,
+        .items[].metadata.uid,
+        .items[].status
+      )' - > "${BACKUP_KUBE_PATH}/${namespace}_kube_resources.yml" &
+  done
+
+  log "Waiting for all exports to complete..."
+  wait
+
+  info "Export complete"
+
   tar_backup
   move_s3
 }


### PR DESCRIPTION
Notable changes:

- Now uses background processes to cut down the overall time and memory usage
- The generated tar file will contain one file per namespace with its resources rather than one big file with the resources from every namespace
- Now uses https://github.com/mikefarah/yq instead of https://github.com/kislyuk/yq (`jq` has also been removed due to this change as the former does not depend on it)